### PR TITLE
Randomized comments, removed the notice from MAD

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,7 +7,7 @@ class CommentsController < ApplicationController
   # GET /comments
   # GET /comments.json
   def index
-    @comments = Comment.search(params[:search]).order(sort_column + " " + sort_direction).page(params[:page]).per(10)
+    @comments = Comment.search(params[:search]).order(sort_column + " " + sort_direction).order(Arel.sql('RANDOM()'))(params[:page]).per(10)
     respond_to do |format|
       format.html # index.html.erb
       format.json { render json: @comments }

--- a/app/controllers/making_a_differences_controller.rb
+++ b/app/controllers/making_a_differences_controller.rb
@@ -1,11 +1,11 @@
 class MakingADifferencesController < ApplicationController
    load_and_authorize_resource :except => [:index]
    before_action :set_making_a_difference, only: [:show, :edit, :update, :destroy]
- 
+   
   # GET /making_a_differences
   def index
-    @children_comments = MakingADifference.where(type_of_life: "Children").page(params[:children_page]).per(8)
-    @parents_comments = MakingADifference.where(type_of_life: "Parents").page(params[:parent_page]).per(8)
+    @children_comments = MakingADifference.where(type_of_life: "Children").order(Arel.sql('RANDOM()')).page(params[:children_page]).per(8)
+    @parents_comments = MakingADifference.where(type_of_life: "Parents").order(Arel.sql('RANDOM()')).page(params[:parent_page]).per(8)
   end
 
   # GET /making_a_differences/1

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -9,7 +9,7 @@ class StaticController < ApplicationController
       @comments = @comments.where(activity: params[:type])
     end
 
-    @comments = @comments.where(score: 8..10).page(params[:page]).per(4)
+    @comments = @comments.where(score: 8..10).order(Arel.sql('RANDOM()')).page(params[:page]).per(4)
   end
 
   def gymnastics

--- a/app/views/making_a_differences/index.html.erb
+++ b/app/views/making_a_differences/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <style>
 .MADcontainer {
   border-radius: 10px;

--- a/app/views/making_a_differences/show.html.erb
+++ b/app/views/making_a_differences/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 
 <p>
   <strong>Comment:</strong>


### PR DESCRIPTION
Comments will display random every time it is refreshed, for MAD and Testimonials. The id='notice' is removed from the from and index of MAD 